### PR TITLE
Realign FFI types to matchup with types that should be used

### DIFF
--- a/libressl.cabal
+++ b/libressl.cabal
@@ -53,7 +53,6 @@ library
   -- Modules exported by the library.
   exposed-modules:     Network.Libre.TLS
                       ,Network.Libre.TLS.FFI.Internal
-
   -- Modules included in this library but not exported.
   -- other-modules:
 
@@ -62,10 +61,10 @@ library
 
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.9 && <4.10
-                       ,transformers >= 0.5
-                       ,vector >= 0.11 && < 0.12
-                       ,primitive >= 0.6 && < 0.7
-                       ,monad-ste >= 0.1 && < 0.2
+                     , transformers >= 0.5
+                     , vector >= 0.11 && < 0.12
+                     , primitive >= 0.6 && < 0.7
+                     , monad-ste >= 0.1 && < 0.2
   if os(OSX)
     extra-lib-dirs: /usr/local/opt/libressl/lib
   if os(linux)

--- a/src/Network/Libre/TLS/FFI/Internal.hs
+++ b/src/Network/Libre/TLS/FFI/Internal.hs
@@ -181,7 +181,7 @@ foreign import ccall safe "tls_handshake" tls_handshake_c :: TLSPtr -> IO CInt
 foreign import ccall safe "tls_read" tls_read_c :: TLSPtr -> CString -> CSize -> IO CSsize
 
 --ssize_t tls_write(struct tls *_ctx, const void *_buf, size_t _buflen);
-foreign import ccall safe "tls_write" tls_write_c :: TLSPtr -> CString -> CSize -> IO CInt
+foreign import ccall safe "tls_write" tls_write_c :: TLSPtr -> CString -> CSize -> IO CSsize
 
 --int tls_close(struct tls *_ctx);
 foreign import ccall safe "tls_close" tls_close_c :: TLSPtr -> IO CInt


### PR DESCRIPTION
Most of the Ptr Word8 are just CStrings and the return type of tls_read_c should be CSsize from System.Posix.Types instead of CSize because of the possible negative value.
